### PR TITLE
ci: configure Mergify to enable Renovate automerge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,21 @@
+pull_request_rules:
+  - name: Automatic merge Renovate PRs
+    conditions:
+      - '#approved-reviews-by>=1'
+      - 'author=balvajs-renovate[bot]'
+    actions:
+      queue:
+        name: default
+        method: squash
+  - name: Automatic approval to Renovate PRs
+    conditions:
+      - body~=\*\*Automerge\*\*. Enabled
+    actions:
+      review:
+        type: APPROVE
+        bot_account: Balvajs
+
+queue_rules:
+  - name: default
+    queue_conditions:
+      - '#approved-reviews-by>=1'


### PR DESCRIPTION
This change has been made by @Balvajs from Mergify config editor.